### PR TITLE
Refactor ghost boss to summon multiple enemies

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -897,8 +897,8 @@ function startGame() {
         onDestroyed(): void {
             return
         }
-        attack1():void {
-            return
+        attack1(): enemy[] {
+            return []
         }
     }
 
@@ -977,7 +977,7 @@ function startGame() {
             }
         }
 
-        attack1() {
+        attack1(): enemy[] {
             //if car sprite exsists and player is not already stunned create target sprite at current player position and shoots enemy projectile at target
             if (this.sprite != null && playerStunned == false) {
 
@@ -988,8 +988,9 @@ function startGame() {
                 let enemyProjectile = sprites.createProjectileFromSprite(assets.image`enemyProjectile`, this.sprite, 1, 1)
                 enemyProjectile.setKind(SpriteKind.CarProjectile)
                 enemyProjectile.follow(target, carProjectileSpeed)
-                
+
             }
+            return []
         }
     }
 
@@ -1055,9 +1056,20 @@ function startGame() {
             }
         }
 
-        attack1() {
-            let e = new enemy1(this.sprite.x - 20, this.sprite.y)
-            enemies.push(e)
+        attack1(): enemy[] {
+            let spawned: enemy[] = []
+            for (let i = 0; i < 3; i++) {
+                let ex = this.sprite.x + randint(-20, 20)
+                let ey = this.sprite.y + randint(-20, 20)
+                if (ey < minY) {
+                    ey = minY
+                } else if (ey > screen.height - 10) {
+                    ey = screen.height - 10
+                }
+                let e = new enemy1(ex, ey)
+                spawned.push(e)
+            }
+            return spawned
         }
     }
 
@@ -1065,7 +1077,10 @@ function startGame() {
     game.onUpdateInterval(ghostAttackInterval, function () {
         for (let b of bosses) {
             if (b.type == BossType.ghost) {
-                b.attack1()
+                let spawned = b.attack1()
+                for (let e of spawned) {
+                    enemies.push(e)
+                }
             }
         }
     })


### PR DESCRIPTION
## Summary
- allow boss attacks to return multiple enemies
- update ghost boss to spawn a cluster of snake enemies nearby
- collect all spawned enemies in the update loop

## Testing
- `npm install pxt --save-dev` (fails: 403 Forbidden)
- `make test` (fails: pxt: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_6897a9f4c28083309d018053bc083363