### PR TITLE
Display timer in minutes and seconds

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -540,12 +540,14 @@ function startGame() {
 
     //timer
     let time = 0
-    let timerText = textsprite.create(`${time}`,0,15)
-    timerText.setPosition(80,5)
+    let timerText = textsprite.create("0:00", 0, 15)
+    timerText.setPosition(80, 5)
     timerText.z = 6
     game.onUpdateInterval(1000, function () {
         time++
-        timerText.setText(`${time}`)
+        let mins = Math.idiv(time, 60)
+        let secs = time % 60
+        timerText.setText(`${mins}:${secs < 10 ? "0" : ""}${secs}`)
     })
 
     //enemy1 count bar


### PR DESCRIPTION
## Summary
- show elapsed time as minutes and seconds instead of raw seconds

## Testing
- `pxt test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689cfa18fb6c83308b3c7e725d6cb73e